### PR TITLE
Fixed an unmute bug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ PushedNotificationAccessory.prototype =
 
     if (this.stateValue == 1) {
       // 'that' is used inside timeout functions
-      that = this;
+      var that = this;
 
       // Clear the On value after 250 milliseconds 
       setTimeout(function() {that.stateValue = 0; that.btnService.setCharacteristic(Characteristic.On, 0) }, 500 );


### PR DESCRIPTION
Without `var`, the variable `that` would be a kinda global variable. Which cases that when multiple timers are running very closely, unmute timer blocks unmutes the wrong switch.

STEPS TO PRODUCE THE BUG:

1. Switch A has mute interval: 5s.
2. Switch B has mute interval: 2s.
3. Turn on A.
4. Turn on B right away.
5. After 2s, B is unmuted.
6. After another 3s, B is unmuted again, but it should be A that gets unmuted. (because A's unmute timer block picks up the global variable `that` which was assigned to B)